### PR TITLE
fix: Handle geometry in return_query (fix missing geometry in export through API)

### DIFF
--- a/src/utils_flask_sqla_geo/generic.py
+++ b/src/utils_flask_sqla_geo/generic.py
@@ -137,6 +137,12 @@ class GenericQueryGeo(GenericQuery):
             srid=srid,
         )
 
+    def return_query(self):
+        if self.geometry_field:
+            return self.as_geofeature()
+        else:
+            return super(GenericQueryGeo, self).return_query()
+
     def as_geofeature(self):
         data, nb_result_without_filter, nb_results = self.query()
 


### PR DESCRIPTION
Closes #30

Pour la compréhension de la PR, voir l'issue correspondante qui est assez détaillée. 

Je joins deux fichiers, qui présentent les résultats d'export par api avec geométrie avant/après la modification. 

[export_sans_modification.json](https://github.com/user-attachments/files/16028666/export_sans_modification.json)

[export_avec_modification.json](https://github.com/user-attachments/files/16028665/export_avec_modification.json)
