### PR TITLE
fix: prevent keeping geom columns from one export to another

### DIFF
--- a/src/utils_flask_sqla_geo/export.py
+++ b/src/utils_flask_sqla_geo/export.py
@@ -33,7 +33,7 @@ def export_csv(
         geometry_field_name (_type_, optional): nom du champ pour la colonne geométrique. Defaults to None.
     """
     # gestion de only
-    only = columns
+    only = columns.copy()
 
     # ajout du champs geométrique si demandé (sera exporté en WKT)
     if geometry_field_name:


### PR DESCRIPTION
Before this fix, the `only` variable was poiting to the same reference as the `columns`variable.

So each time a geometry column was added, it was kept in the `columns` list, which would expand indefinitely the list and mix the columns from different exports.

In this example, I have 2 exports, one with a geometry column named `the_geom_local` another with `geom`. 

I triggered the First export twice without error.
I then triggered the second export, which failed, but kept its column `geom`in the list when i re triggered the second export a second time

<img width="1045" alt="Capture d’écran 2024-09-24 à 10 24 38" src="https://github.com/user-attachments/assets/ad7d46d7-82f1-4164-9f54-94f601a50678">
