### PR TITLE
drop marshmallow-geojson since not up to date with latest version of marshmallow

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,5 +4,4 @@ geoalchemy2>=0.4.0
 shapely>=1.8.5.post1
 utils-flask-sqlalchemy>=0.4.2
 marshmallow_sqlalchemy
-marshmallow_geojson
 geojson

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,15 @@
 #
 #    pip-compile requirements.in
 #
-alembic==1.15.2
+alembic==1.16.5
     # via flask-migrate
-attrs==25.3.0
+attrs==25.4.0
     # via fiona
+backports-datetime-fromisoformat==2.0.3
+    # via marshmallow
 blinker==1.9.0
     # via flask
-certifi==2025.4.26
+certifi==2026.1.4
     # via fiona
 click==8.1.8
     # via
@@ -18,13 +20,13 @@ click==8.1.8
     #   cligj
     #   fiona
     #   flask
-click-plugins==1.1.1
+click-plugins==1.1.1.2
     # via fiona
 cligj==0.7.2
     # via fiona
 fiona==1.10.1
     # via -r requirements.in
-flask==3.1.1
+flask==3.1.2
     # via
     #   flask-migrate
     #   flask-sqlalchemy
@@ -39,9 +41,9 @@ geoalchemy2==0.17.1
     # via -r requirements.in
 geojson==3.2.0
     # via -r requirements.in
-greenlet==3.2.2
+greenlet==3.2.4
     # via sqlalchemy
-importlib-metadata==8.7.0
+importlib-metadata==8.7.1
     # via
     #   fiona
     #   flask
@@ -51,27 +53,22 @@ jinja2==3.1.6
     # via flask
 mako==1.3.10
     # via alembic
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   flask
     #   jinja2
     #   mako
     #   werkzeug
-marshmallow==3.26.1
+marshmallow==4.0.1
     # via
-    #   marshmallow-geojson
     #   marshmallow-sqlalchemy
     #   utils-flask-sqlalchemy
-marshmallow-geojson==0.5.0
-    # via -r requirements.in
 marshmallow-sqlalchemy==1.4.2
     # via -r requirements.in
 numpy==2.0.2
     # via shapely
 packaging==25.0
-    # via
-    #   geoalchemy2
-    #   marshmallow
+    # via geoalchemy2
 python-dateutil==2.9.0.post0
     # via utils-flask-sqlalchemy
 shapely==2.0.7
@@ -86,13 +83,16 @@ sqlalchemy==1.4.54
     #   geoalchemy2
     #   marshmallow-sqlalchemy
     #   utils-flask-sqlalchemy
-typing-extensions==4.13.2
+tomli==2.4.0
+    # via alembic
+typing-extensions==4.15.0
     # via
     #   alembic
+    #   marshmallow
     #   marshmallow-sqlalchemy
-utils-flask-sqlalchemy==0.4.2
+utils-flask-sqlalchemy==0.4.3
     # via -r requirements.in
-werkzeug==3.1.3
+werkzeug==3.1.5
     # via flask
-zipp==3.21.0
+zipp==3.23.0
     # via importlib-metadata

--- a/src/utils_flask_sqla_geo/schema.py
+++ b/src/utils_flask_sqla_geo/schema.py
@@ -9,20 +9,144 @@ from geoalchemy2 import Geometry
 from geoalchemy2.shape import to_shape, from_shape
 from marshmallow_sqlalchemy.schema import SQLAlchemyAutoSchema, SQLAlchemyAutoSchemaOpts
 from marshmallow_sqlalchemy.convert import ModelConverter
-from marshmallow_geojson import (
-    GeometryType,
-    PointSchema,
-    MultiPointSchema,
-    PolygonSchema,
-    MultiPolygonSchema,
-    LineStringSchema,
-    MultiLineStringSchema,
-)
 from shapely.geometry import shape
 from shapely import wkt
 from shapely.errors import ShapelyError
 
 from .utils import JsonifiableGenerator, GeneratorField
+
+from marshmallow import Schema, fields, validates, ValidationError
+
+
+class GeometryType(Enum):
+
+    point = "Point"
+    multi_point = "MultiPoint"
+    line_string = "LineString"
+    multi_line_string = "MultiLineString"
+    polygon = "Polygon"
+    multi_polygon = "MultiPolygon"
+    geometry_collection = "GeometryCollection"
+
+
+class PositionField(fields.Field):
+    """Field for validating GeoJSON position (longitude, latitude, [altitude])"""
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if not isinstance(value, list):
+            raise ValidationError("Position must be a list")
+
+        if len(value) < 2:
+            raise ValidationError("Position must have at least 2 coordinates")
+
+        if len(value) > 3:
+            raise ValidationError("Position must have at most 3 coordinates")
+
+        for coord in value:
+            if not isinstance(coord, (int, float)):
+                raise ValidationError("Position coordinates must be numbers")
+
+        # Validate longitude range
+        if not -180 <= value[0] <= 180:
+            raise ValidationError("Longitude must be between -180 and 180")
+
+        # Validate latitude range
+        if not -90 <= value[1] <= 90:
+            raise ValidationError("Latitude must be between -90 and 90")
+
+        return value
+
+
+class PointSchema(Schema):
+    """Schema for GeoJSON Point geometry"""
+
+    type = fields.Constant("Point", required=True)
+    coordinates = PositionField(required=True)
+
+
+class MultiPointSchema(Schema):
+    """Schema for GeoJSON MultiPoint geometry"""
+
+    type = fields.Constant("MultiPoint", required=True)
+    coordinates = fields.List(PositionField(), required=True)
+
+    @validates("coordinates")
+    def validate_coordinates(self, value):
+        if len(value) == 0:
+            raise ValidationError("MultiPoint must have at least one position")
+
+
+class LineStringSchema(Schema):
+    """Schema for GeoJSON LineString geometry"""
+
+    type = fields.Constant("LineString", required=True)
+    coordinates = fields.List(PositionField(), required=True)
+
+    @validates("coordinates")
+    def validate_coordinates(self, value):
+        if len(value) < 2:
+            raise ValidationError("LineString must have at least 2 positions")
+
+
+class MultiLineStringSchema(Schema):
+    """Schema for GeoJSON MultiLineString geometry"""
+
+    type = fields.Constant("MultiLineString", required=True)
+    coordinates = fields.List(fields.List(PositionField()), required=True)
+
+    @validates("coordinates")
+    def validate_coordinates(self, value):
+        if len(value) == 0:
+            raise ValidationError("MultiLineString must have at least one LineString")
+
+        for linestring in value:
+            if len(linestring) < 2:
+                raise ValidationError("Each LineString must have at least 2 positions")
+
+
+class PolygonSchema(Schema):
+    """Schema for GeoJSON Polygon geometry"""
+
+    type = fields.Constant("Polygon", required=True)
+    coordinates = fields.List(fields.List(PositionField()), required=True)
+
+    @validates("coordinates")
+    def validate_coordinates(self, value):
+        if len(value) == 0:
+            raise ValidationError("Polygon must have at least one linear ring")
+
+        for ring in value:
+            if len(ring) < 4:
+                raise ValidationError("Linear ring must have at least 4 positions")
+
+            # Verify ring is closed (first and last positions are the same)
+            if ring[0] != ring[-1]:
+                raise ValidationError(
+                    "Linear ring must be closed (first and last positions must match)"
+                )
+
+
+class MultiPolygonSchema(Schema):
+    """Schema for GeoJSON MultiPolygon geometry"""
+
+    type = fields.Constant("MultiPolygon", required=True)
+    coordinates = fields.List(fields.List(fields.List(PositionField())), required=True)
+
+    @validates("coordinates")
+    def validate_coordinates(self, value):
+        if len(value) == 0:
+            raise ValidationError("MultiPolygon must have at least one Polygon")
+
+        for polygon in value:
+            if len(polygon) == 0:
+                raise ValidationError("Each Polygon must have at least one linear ring")
+
+            for ring in polygon:
+                if len(ring) < 4:
+                    raise ValidationError("Linear ring must have at least 4 positions")
+
+                if ring[0] != ring[-1]:
+                    raise ValidationError("Linear ring must be closed")
 
 
 class GeometrySchema(Schema):

--- a/src/utils_flask_sqla_geo/schema.py
+++ b/src/utils_flask_sqla_geo/schema.py
@@ -329,7 +329,7 @@ class GeoAlchemyAutoSchema(SQLAlchemyAutoSchema):
             result = super(GeoAlchemyAutoSchema, self)._serialize(obj, many=False)
             return result
 
-    @post_dump(pass_many=True)
+    @post_dump(pass_collection=True)
     def to_geojson(self, data, many, **kwargs):
         if self.as_geojson:
             if many:
@@ -344,7 +344,7 @@ class GeoAlchemyAutoSchema(SQLAlchemyAutoSchema):
                 data = JsonifiableGenerator(data)
             return data
 
-    @pre_load(pass_many=True)
+    @pre_load(pass_collection=True)
     def from_geojson(self, data, many, **kwargs):
         if not self.as_geojson:
             return data

--- a/src/utils_flask_sqla_geo/schema.py
+++ b/src/utils_flask_sqla_geo/schema.py
@@ -1,3 +1,4 @@
+import collections
 from enum import Enum
 
 from marshmallow import Schema, fields, RAISE, EXCLUDE
@@ -33,7 +34,7 @@ class PositionField(fields.Field):
     """Field for validating GeoJSON position (longitude, latitude, [altitude])"""
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if not isinstance(value, list):
+        if not isinstance(value, collections.abc.Iterable):
             raise ValidationError("Position must be a list")
 
         if len(value) < 2:
@@ -71,7 +72,7 @@ class MultiPointSchema(Schema):
     coordinates = fields.List(PositionField(), required=True)
 
     @validates("coordinates")
-    def validate_coordinates(self, value):
+    def validate_coordinates(self, value, **kwargs):
         if len(value) == 0:
             raise ValidationError("MultiPoint must have at least one position")
 
@@ -83,7 +84,7 @@ class LineStringSchema(Schema):
     coordinates = fields.List(PositionField(), required=True)
 
     @validates("coordinates")
-    def validate_coordinates(self, value):
+    def validate_coordinates(self, value, **kwargs):
         if len(value) < 2:
             raise ValidationError("LineString must have at least 2 positions")
 
@@ -95,7 +96,7 @@ class MultiLineStringSchema(Schema):
     coordinates = fields.List(fields.List(PositionField()), required=True)
 
     @validates("coordinates")
-    def validate_coordinates(self, value):
+    def validate_coordinates(self, value, **kwargs):
         if len(value) == 0:
             raise ValidationError("MultiLineString must have at least one LineString")
 
@@ -111,7 +112,7 @@ class PolygonSchema(Schema):
     coordinates = fields.List(fields.List(PositionField()), required=True)
 
     @validates("coordinates")
-    def validate_coordinates(self, value):
+    def validate_coordinates(self, value, **kwargs):
         if len(value) == 0:
             raise ValidationError("Polygon must have at least one linear ring")
 
@@ -133,7 +134,7 @@ class MultiPolygonSchema(Schema):
     coordinates = fields.List(fields.List(fields.List(PositionField())), required=True)
 
     @validates("coordinates")
-    def validate_coordinates(self, value):
+    def validate_coordinates(self, value, **kwargs):
         if len(value) == 0:
             raise ValidationError("MultiPolygon must have at least one Polygon")
 
@@ -171,8 +172,8 @@ class FeatureSchema(Schema):
     id = fields.Field()
     type = fields.Constant("Feature", required=True)
     # note: geometry validity done by GeometryField deserialization
-    geometry = fields.Mapping(required=True, allow_none=True)
-    properties = fields.Mapping(required=True)
+    geometry = fields.Dict(required=True, allow_none=True)
+    properties = fields.Dict(required=True)
 
 
 class FeatureCollectionSchema(Schema):


### PR DESCRIPTION
With the update of marshmallow to 4.x.x, bug happens with marshmallow_geojson cause it used deprecated object (https://github.com/folt/marshmallow-geojson/issues/92). Unfortunately, the package author does not answer... Since, we use but a portion of the library (geojson schema), we decide to create our own GeoJSON schema